### PR TITLE
Merged cakephp-plugin-template v3.2.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.bat]
+end_of_line = crlf
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 vendor/
 composer.lock
+config/Migrations/schema-dump-default.lock
+config/Migrations/schema-dump-test.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ sudo: false
 env:
   matrix:
     - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
-    - DB=sqlite db_dsn='sqlite:///:memory:'
   global:
     - DEFAULT=1
 
@@ -19,17 +17,15 @@ matrix:
   fast_finish: true
 
 install:
-  - composer install 
+  - composer install --no-interaction --no-progress --no-suggest
   - mkdir -p build/logs
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
 
 script:
   - vendor/bin/phpunit
-  - vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
-  - vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests
+  - vendor/bin/phpcs
 
 after_success:
   - curl -s https://codecov.io/bash > /tmp/codecov.sh

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "maiconpinto/cakephp-adminlte-theme": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "^5.0",
         "cakephp/cakephp-codesniffer": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "type": "cakephp-plugin",
     "license": "GPL-2.0",
     "require": {
-        "php": ">=5.4.16",
         "cakephp/cakephp": "~3.0",
         "fzaninotto/faker": "*",
         "muffin/slug": "1.1.0"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "cakephp/cakephp": "~3.3.0",
         "fzaninotto/faker": "*",
-        "muffin/slug": "1.1.0"
+        "muffin/slug": "1.1.0",
+        "maiconpinto/cakephp-adminlte-theme": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Cms\\": "src"
+            "Cms\\": "src",
+            "Cms\\Test\\Fixture\\": "tests\\Fixture"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "license": "GPL-2.0",
     "require": {
-        "cakephp/cakephp": "~3.0",
+        "cakephp/cakephp": "~3.3.0",
         "fzaninotto/faker": "*",
         "muffin/slug": "1.1.0"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+    <!--
+         Useful links:
+         * https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage
+         * https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xml.dist
+         * https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    -->
+    <description>PHP CodeSniffer Configuration</description>
+
+    <!-- Coding standard to use -->
+    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP" />
+
+    <!-- Do not fail on warnings -->
+    <config name="ignore_warnings_on_exit" value="1" />
+
+    <!-- Assume UTF-8 -->
+    <config name="encoding" value="UTF-8" />
+
+    <!-- Extensions to check -->
+    <arg name="extensions" value="php,inc,ctp,js,css" />
+
+    <!-- Use colors -->
+    <arg name="colors" />
+
+    <!-- Show progress -->
+    <arg value="p" />
+
+    <!-- Files and directories to check -->
+    <file>./src/</file>
+    <file>./tests/</file>
+    <file>./webroot/</file>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,37 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    colors="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    syntaxCheck="false"
-    bootstrap="./vendor/cakephp/cakephp/tests/bootstrap.php"
+	colors="true"
+	processIsolation="false"
+	stopOnFailure="false"
+	syntaxCheck="false"
+	bootstrap="./tests/bootstrap.php"
     verbose="true"
-    >
-    <php>
-        <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
-    </php>
+	>
+	<php>
+		<ini name="memory_limit" value="-1"/>
+		<ini name="apc.enable_cli" value="1"/>
+	</php>
 
 	<filter>
 		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory>./build/</directory>
-				<directory>./config/</directory>
-				<directory>./doc/</directory>
-				<directory>./tests/</directory>
-				<directory>./vendor/</directory>
-			</exclude>
+            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">./webroot/</directory>
 		</whitelist>
 	</filter>
 
-	<logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+    <logging>
+		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
 		<log type="coverage-html" target="build/coverage"/>
 		<log type="coverage-clover" target="build/logs/clover.xml"/>
 		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
 		<log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
-	</logging>
+    </logging>
 
     <!-- Setup a listener for fixtures -->
     <listeners>

--- a/src/Template/Articles/edit.ctp
+++ b/src/Template/Articles/edit.ctp
@@ -1,5 +1,6 @@
 <?php
 use Cake\Core\Configure;
+
 $this->extend('QoboAdminPanel./Common/panel-wrapper');
 $this->assign('panel-title', __d('QoboAdminPanel', __('Edit {0}', $article->title)));
 $idContent = 'article-content';
@@ -33,9 +34,9 @@ $idContent = 'article-content';
                 <?= $this->Form->file('file', ['class' => 'hidden']); ?>
                 <?= $this->Form->error('file', ['class' => 'hidden']); ?>
                 <?= $this->Html->link(
-                        __d('cms', 'Preview'),
-                        '#',
-                        ['data-target' => '#featuredImage', 'data-toggle' => 'modal']
+                    __d('cms', 'Preview'),
+                    '#',
+                    ['data-target' => '#featuredImage', 'data-toggle' => 'modal']
                 );
                 ?>
             </div>

--- a/src/Template/Categories/index.ctp
+++ b/src/Template/Categories/index.ctp
@@ -11,7 +11,7 @@ $this->assign('panel-title', __d('QoboAdminPanel', 'View all'));
         </tr>
     </thead>
     <tbody>
-        <?php foreach ($categories as $category): ?>
+        <?php foreach ($categories as $category) : ?>
         <tr>
             <td><?= $category->node ?></td>
             <td class="actions">

--- a/src/Template/Categories/view.ctp
+++ b/src/Template/Categories/view.ctp
@@ -41,7 +41,7 @@
     <div class="panel-heading">
         <h3 class="panel-title"><?= __('Related Categories') ?></h3>
     </div>
-    <?php if (!empty($category->child_categories)): ?>
+    <?php if (!empty($category->child_categories)) : ?>
         <table class="table table-striped">
             <thead>
             <tr>
@@ -51,7 +51,7 @@
             </tr>
             </thead>
             <tbody>
-            <?php foreach ($category->child_categories as $childCategories): ?>
+            <?php foreach ($category->child_categories as $childCategories) : ?>
                 <tr>
                     <td><?= h($childCategories->slug) ?></td>
                     <td><?= h($childCategories->name) ?></td>
@@ -64,7 +64,7 @@
             <?php endforeach; ?>
             </tbody>
         </table>
-    <?php else: ?>
+    <?php else : ?>
         <p class="panel-body">no related Categories</p>
     <?php endif; ?>
 </div>
@@ -73,7 +73,7 @@
     <div class="panel-heading">
         <h3 class="panel-title"><?= __('Related Articles') ?></h3>
     </div>
-    <?php if (!empty($category->articles)): ?>
+    <?php if (!empty($category->articles)) : ?>
         <table class="table table-striped">
             <thead>
             <tr>
@@ -91,7 +91,7 @@
             </tr>
             </thead>
             <tbody>
-            <?php foreach ($category->articles as $articles): ?>
+            <?php foreach ($category->articles as $articles) : ?>
                 <tr>
                     <td><?= h($articles->id) ?></td>
                     <td><?= h($articles->title) ?></td>
@@ -112,7 +112,7 @@
             <?php endforeach; ?>
             </tbody>
         </table>
-    <?php else: ?>
+    <?php else : ?>
         <p class="panel-body">no related Articles</p>
     <?php endif; ?>
 </div>

--- a/src/Template/Element/status-fixed-bar.ctp
+++ b/src/Template/Element/status-fixed-bar.ctp
@@ -13,10 +13,7 @@ foreach ($editableEntites as $entity) {
     <nav class="navbar navbar-inverse navbar-fixed-bottom">
         <div class="container">
             <ul class="nav navbar-nav">
-                <li><?= $this->Html->link(
-                    __d('cms', 'Edit Page'),
-                    ['action' => 'edit', $id]
-                ); ?></li>
+                <li><?= $this->Html->link(__d('cms', 'Edit Page'), ['action' => 'edit', $id]); ?></li>
             </ul>
         </div>
     </nav>

--- a/tests/App/Controller/AppController.php
+++ b/tests/App/Controller/AppController.php
@@ -1,0 +1,9 @@
+<?php
+namespace Foobar\Test\App\Controller;
+
+use \Cake\Controller\Controller;
+
+class AppController extends Controller
+{
+    public $components = ['Auth', 'Flash', 'RequestHandler'];
+}

--- a/tests/App/Controller/UsersController.php
+++ b/tests/App/Controller/UsersController.php
@@ -1,0 +1,14 @@
+<?php
+namespace Foobar\Test\App\Controller;
+
+use \Cake\Controller\Controller;
+
+class UsersController extends Controller
+{
+    /**
+     * Simple users login action
+     */
+    public function login()
+    {
+    }
+}

--- a/tests/App/Template/Error/error400.ctp
+++ b/tests/App/Template/Error/error400.ctp
@@ -1,0 +1,5 @@
+<?php
+use Cake\Routing\Router;
+?>
+<b><?= __d('cake', 'Error') ?> <?= h($code) ?>: <?= h($message) ?></b>
+<b>URL: </b><?= h(Router::url($url, true)) ?>

--- a/tests/App/Template/Error/error500.ctp
+++ b/tests/App/Template/Error/error500.ctp
@@ -1,0 +1,5 @@
+<?php
+use Cake\Routing\Router;
+?>
+<b><?= __d('cake', 'Error') ?> <?= h($code) ?>: <?= h($message) ?></b>
+<b>URL: </b><?= h(Router::url($url, true)) ?>

--- a/tests/App/Template/Layout/default.ctp
+++ b/tests/App/Template/Layout/default.ctp
@@ -1,0 +1,3 @@
+<?php
+// Simplified layout
+echo $this->fetch('content');

--- a/tests/App/Template/Users/login.ctp
+++ b/tests/App/Template/Users/login.ctp
@@ -1,0 +1,3 @@
+<strong>Login</strong><br />
+Username:<br />
+Password:<br />

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -1,0 +1,48 @@
+<?php
+namespace Foobar\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * UsersFixture
+ *
+ */
+class UsersFixture extends TestFixture
+{
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'name' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        'primary_key' => ['type' => 'uuid', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => '00000000-0000-0000-0000-000000000001',
+            'name' => 'user1',
+        ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000002',
+            'name' => 'user2',
+        ],
+    ];
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,116 @@
+<?php
+// @codingStandardsIgnoreFile
+
+use Cake\Core\Configure;
+use Cake\Filesystem\Folder;
+
+//$pluginName = 'Foobar';
+if (empty($pluginName)) {
+    throw new \Exception("Plugin name is not configured");
+}
+
+$findRoot = function () {
+    $root = dirname(__DIR__);
+    if (is_dir($root . '/vendor/cakephp/cakephp')) {
+        return $root;
+    }
+
+    $root = dirname(dirname(__DIR__));
+    if (is_dir($root . '/vendor/cakephp/cakephp')) {
+        return $root;
+    }
+
+    $root = dirname(dirname(dirname(__DIR__)));
+    if (is_dir($root . '/vendor/cakephp/cakephp')) {
+        return $root;
+    }
+
+    throw new \Exception("Failed to find CakePHP");
+};
+
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+define('ROOT', $findRoot());
+define('APP_DIR', 'App');
+define('WEBROOT_DIR', 'webroot');
+define('APP', ROOT . '/tests/App/');
+define('CONFIG', ROOT . '/tests/config/');
+define('WWW_ROOT', ROOT . DS . WEBROOT_DIR . DS);
+define('TESTS', ROOT . DS . 'tests' . DS);
+define('TMP', ROOT . DS . 'tmp' . DS);
+define('LOGS', TMP . 'logs' . DS);
+define('CACHE', TMP . 'cache' . DS);
+define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
+define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
+define('CAKE', CORE_PATH . 'src' . DS);
+
+require ROOT . '/vendor/autoload.php';
+require CORE_PATH . 'config/bootstrap.php';
+
+Configure::write('App', [
+    'namespace' => $pluginName . '\Test\App',
+    'paths' => [
+        'templates' => [
+            APP . 'Template' . DS
+        ]
+    ]
+]);
+Configure::write('debug', true);
+
+$TMP = new Folder(TMP);
+$TMP->create(TMP . 'cache/models', 0777);
+$TMP->create(TMP . 'cache/persistent', 0777);
+$TMP->create(TMP . 'cache/views', 0777);
+
+$cache = [
+    'default' => [
+        'engine' => 'File'
+    ],
+    '_cake_core_' => [
+        'className' => 'File',
+        'prefix' => strtolower($pluginName) . '_myapp_cake_core_',
+        'path' => CACHE . 'persistent/',
+        'serialize' => true,
+        'duration' => '+10 seconds'
+    ],
+    '_cake_model_' => [
+        'className' => 'File',
+        'prefix' => strtolower($pluginName) . '_my_app_cake_model_',
+        'path' => CACHE . 'models/',
+        'serialize' => 'File',
+        'duration' => '+10 seconds'
+    ]
+];
+
+Cake\Cache\Cache::config($cache);
+Cake\Core\Configure::write('Session', [
+    'defaults' => 'php'
+]);
+
+// Ensure default test connection is defined
+if (!getenv('db_dsn')) {
+    putenv('db_dsn=sqlite:///:memory:');
+}
+
+Cake\Datasource\ConnectionManager::config('default', [
+    'url' => getenv('db_dsn'),
+    'quoteIdentifiers' => true,
+    'timezone' => 'UTC'
+]);
+
+Cake\Datasource\ConnectionManager::config('test', [
+    'url' => getenv('db_dsn'),
+    'quoteIdentifiers' => true,
+    'timezone' => 'UTC'
+]);
+
+// Alias AppController to the test App
+class_alias($pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
+// If plugin has routes.php/bootstrap.php then load them, otherwise don't.
+$loadPluginRoutes = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'routes.php');
+$loadPluginBootstrap = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'bootstrap.php');
+Cake\Core\Plugin::load($pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);
+
+Cake\Routing\DispatcherFactory::add('Routing');
+Cake\Routing\DispatcherFactory::add('ControllerFactory');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,7 @@
 use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
 
-//$pluginName = 'Foobar';
+$pluginName = 'Cms';
 if (empty($pluginName)) {
     throw new \Exception("Plugin name is not configured");
 }

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -1,0 +1,14 @@
+<?php
+namespace Foobar\Test\App\Config;
+
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+use Cake\Routing\Router;
+
+/**
+ * Load all plugin routes.  See the Plugin documentation on
+ * how to customize the loading of plugin routes.
+ */
+Plugin::routes();
+
+Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);

--- a/webroot/js/ckeditor-config.js
+++ b/webroot/js/ckeditor-config.js
@@ -3,22 +3,22 @@
  * For licensing, see LICENSE.md or http://ckeditor.com/license
  */
 
-CKEDITOR.editorConfig = function( config ) {
+CKEDITOR.editorConfig = function ( config ) {
     // Define changes to default configuration here.
     // For complete reference see:
     // http://docs.ckeditor.com/#!/api/CKEDITOR.config
 
     // The toolbar groups arrangement, optimized for two toolbar rows.
     config.toolbarGroups = [
-        { name: 'clipboard',   groups: [ 'clipboard', 'undo' ] },
-        { name: 'editing',     groups: [ 'find', 'selection', 'spellchecker' ] },
+        { name: 'clipboard', groups: [ 'clipboard', 'undo' ] },
+        { name: 'editing', groups: [ 'find', 'selection', 'spellchecker' ] },
         { name: 'links' },
         { name: 'insert' },
-        { name: 'tools',       groups: ['mode'] },
+        { name: 'tools', groups: ['mode'] },
         { name: 'others' },
         '/',
         { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ] },
-        { name: 'paragraph',   groups: [ 'list', 'indent', 'blocks', 'align'] },
+        { name: 'paragraph', groups: [ 'list', 'indent', 'blocks', 'align'] },
         { name: 'styles' },
         { name: 'colors' },
         { name: 'about' }


### PR DESCRIPTION
Additional changes:

- Added missing plugin name in test `bootstrap.php`.
- Removed PHP requirement in `composer.json`.
- Locked CakePHP to version `3.3.*`.
- Required AdminLTE plugin.
- Locked to PHPUnit version `5.*`.
- Registered test fixtures to psr-4 autoloader.
- Fixed CS errors.