### PR TITLE
Categories refactoring (task #3387)

### DIFF
--- a/config/Migrations/20170313134700_AddTrashedToCategories.php
+++ b/config/Migrations/20170313134700_AddTrashedToCategories.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddTrashedToCategories extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('categories');
+        $table->addColumn('trashed', 'datetime', [
+            'default' => null,
+            'null' => true,
+        ]);
+        $table->update();
+    }
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -5,6 +5,11 @@ Router::plugin(
     'Cms',
     function ($routes) {
         $routes->extensions(['json']);
+
+        $routes->scope('/site', function ($routes) {
+            $routes->connect('/:slug/categories/:action/*', ['controller' => 'Categories'], ['pass' => ['slug']]);
+        });
+
         $routes->fallbacks('DashedRoute');
     }
 );

--- a/src/Controller/CategoriesController.php
+++ b/src/Controller/CategoriesController.php
@@ -26,7 +26,8 @@ class CategoriesController extends AppController
         $categories = $this->Categories
             ->find('all')
             ->contain('Sites')
-            ->order(['lft' => 'ASC']);
+            ->order(['Categories.site_id' => 'ASC', 'Categories.lft' => 'ASC']);
+
         if ($categories->isEmpty()) {
             $this->Flash->set(__('No categories were found. Please add one.'));
 

--- a/src/Controller/CategoriesController.php
+++ b/src/Controller/CategoriesController.php
@@ -17,7 +17,7 @@ class CategoriesController extends AppController
      */
     public function index()
     {
-        $query = $this->Categories->Sites->find('all', ['conditions' => ['active' => true]]);
+        $query = $this->Categories->Sites->find('all', ['conditions' => ['Sites.active' => true]]);
         $sites = $query->all();
 
         $tree = $this->Categories

--- a/src/Controller/CategoriesController.php
+++ b/src/Controller/CategoriesController.php
@@ -35,21 +35,23 @@ class CategoriesController extends AppController
                 $category->node = $tree[$category->id];
             }
         }
-        $this->set(compact('categories'));
+        $this->set(compact('categories', 'sites'));
         $this->set('_serialize', ['categories']);
     }
 
     /**
      * View method
      *
+     * @param string $siteId Site id or slug.
      * @param string|null $id Category id.
      * @return void
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function view($id = null)
+    public function view($siteId, $id = null)
     {
-        $category = $this->Categories->get($id, [
-            'contain' => ['ParentCategories', 'Articles', 'ChildCategories', 'Sites']
+        $site = $this->Categories->getSite($siteId);
+        $category = $this->Categories->getCategoryBySite($id, $site, [
+            'ParentCategories', 'Articles', 'ChildCategories', 'Sites'
         ]);
 
         $this->set('category', $category);
@@ -59,11 +61,15 @@ class CategoriesController extends AppController
     /**
      * Add method
      *
+     * @param string $siteId Site id or slug.
      * @return \Cake\Network\Response|void Redirects on successful add, renders view otherwise.
+     * @throws \InvalidArgumentException
      */
-    public function add()
+    public function add($siteId)
     {
+        $site = $this->Categories->getSite($siteId);
         $category = $this->Categories->newEntity();
+
         if ($this->request->is('post')) {
             $category = $this->Categories->patchEntity($category, $this->request->data);
             if ($this->Categories->save($category)) {
@@ -74,24 +80,28 @@ class CategoriesController extends AppController
                 $this->Flash->error(__('The category could not be saved. Please, try again.'));
             }
         }
-        $categories = $this->Categories->find('treeList', ['spacer' => self::TREE_SPACER]);
-        $sites = $this->Categories->Sites->find('list')->where(['active' => true]);
-        $this->set(compact('category', 'categories', 'sites'));
+        $categories = $this->Categories->find('treeList', [
+            'conditions' => ['Categories.site_id' => $site->id],
+            'spacer' => self::TREE_SPACER
+        ]);
+        // $sites = $this->Categories->Sites->find('list')->where(['active' => true]);
+        $this->set(compact('category', 'categories', 'site'));
         $this->set('_serialize', ['category']);
     }
 
     /**
      * Edit method
      *
+     * @param string $siteId Site id or slug.
      * @param string|null $id Category id.
      * @return \Cake\Network\Response|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Network\Exception\NotFoundException When record not found.
      */
-    public function edit($id = null)
+    public function edit($siteId, $id = null)
     {
-        $category = $this->Categories->get($id, [
-            'contain' => ['Articles']
-        ]);
+        $site = $this->Categories->getSite($siteId);
+        $category = $this->Categories->getCategoryBySite($id, $site);
+
         if ($this->request->is(['patch', 'post', 'put'])) {
             $category = $this->Categories->patchEntity($category, $this->request->data);
             if ($this->Categories->save($category)) {
@@ -102,23 +112,29 @@ class CategoriesController extends AppController
                 $this->Flash->error(__('The category could not be saved. Please, try again.'));
             }
         }
-        $categories = $this->Categories->find('treeList', ['spacer' => self::TREE_SPACER]);
-        $sites = $this->Categories->Sites->find('list')->where(['active' => true]);
-        $this->set(compact('category', 'categories', 'sites'));
+        $categories = $this->Categories->find('treeList', [
+            'conditions' => ['Categories.site_id' => $site->id, 'Categories.id !=' => $category->id],
+            'spacer' => self::TREE_SPACER
+        ]);
+        $this->set(compact('category', 'categories', 'site'));
         $this->set('_serialize', ['category']);
     }
 
     /**
      * Delete method
      *
+     * @param string $siteId Site id or slug.
      * @param string|null $id Category id.
      * @return \Cake\Network\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete($id = null)
+    public function delete($siteId, $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
-        $category = $this->Categories->get($id);
+
+        $site = $this->Categories->getSite($siteId);
+        $category = $this->Categories->getCategoryBySite($id, $site);
+
         if ($this->Categories->delete($category)) {
             $this->Flash->success(__('The category has been deleted.'));
         } else {
@@ -131,12 +147,13 @@ class CategoriesController extends AppController
     /**
      * Move the node.
      *
+     * @param string $siteId Site id or slug
      * @param  string $id category id
      * @param  string $action move action
      * @throws InvalidPrimaryKeyException When provided id is invalid.
      * @return \Cake\Network\Response|null
      */
-    public function moveNode($id = null, $action = '')
+    public function moveNode($siteId, $id = null, $action = '')
     {
         $moveActions = ['up', 'down'];
         if (!in_array($action, $moveActions)) {
@@ -144,12 +161,14 @@ class CategoriesController extends AppController
 
             return $this->redirect(['action' => 'index']);
         }
-        $node = $this->Categories->get($id);
+
+        $site = $this->Categories->getSite($siteId);
+        $category = $this->Categories->getCategoryBySite($id, $site);
         $moveFunction = 'move' . $action;
-        if ($this->Categories->{$moveFunction}($node)) {
-            $this->Flash->success(__('{0} has been moved {1} successfully.', $node->name, $action));
+        if ($this->Categories->{$moveFunction}($category)) {
+            $this->Flash->success(__('{0} has been moved {1} successfully.', $category->name, $action));
         } else {
-            $this->Flash->error(__('Fail to move {0} {1}.', $node->name, $action));
+            $this->Flash->error(__('Fail to move {0} {1}.', $category->name, $action));
         }
 
         return $this->redirect(['action' => 'index']);

--- a/src/Controller/CategoriesController.php
+++ b/src/Controller/CategoriesController.php
@@ -17,6 +17,9 @@ class CategoriesController extends AppController
      */
     public function index()
     {
+        $query = $this->Categories->Sites->find('all', ['conditions' => ['active' => true]]);
+        $sites = $query->all();
+
         $tree = $this->Categories
             ->find('treeList', ['spacer' => self::TREE_SPACER])
             ->toArray();

--- a/src/Model/Table/CategoriesTable.php
+++ b/src/Model/Table/CategoriesTable.php
@@ -1,7 +1,9 @@
 <?php
 namespace Cms\Model\Table;
 
+use ArrayObject;
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Event\Event;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -37,7 +39,6 @@ class CategoriesTable extends Table
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('Tree');
-        $this->addBehavior('Muffin/Slug.Slug');
 
         $this->belongsTo('Cms.Sites');
         $this->belongsTo('ParentCategories', [
@@ -95,6 +96,23 @@ class CategoriesTable extends Table
         $rules->add($rules->existsIn(['parent_id'], 'ParentCategories'));
 
         return $rules;
+    }
+
+    /**
+     * beforeMarshal callback
+     *
+     * @param \Cake\Event\Event $event Event object
+     * @param \ArrayAccess $data Request data
+     * @param \ArrayAccess $options Query options
+     * @return void
+     */
+    public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
+    {
+        $this->addBehavior('Muffin/Slug.Slug', [
+            'scope' => [
+                'Categories.site_id' => $data['site_id']
+            ]
+        ]);
     }
 
     /**

--- a/src/Model/Table/CategoriesTable.php
+++ b/src/Model/Table/CategoriesTable.php
@@ -134,7 +134,7 @@ class CategoriesTable extends Table
                     'Sites.id' => $id,
                     'Sites.slug' => $id
                 ],
-                'active' => true
+                'Sites.active' => true
             ]
         ]);
 

--- a/src/Model/Table/CategoriesTable.php
+++ b/src/Model/Table/CategoriesTable.php
@@ -130,4 +130,41 @@ class CategoriesTable extends Table
 
         return $result;
     }
+
+    /**
+     * Fetch and return Category by id or slug and associated Site id.
+     *
+     * @param string $id Site id or slug.
+     * @param \Cake\ORM\Entity $site Site entity.
+     * @param array $contain Contain associations list (optional).
+     * @return \Cake\ORM\Entity
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException
+     * @throws \InvalidArgumentException
+     */
+    public function getCategoryBySite($id, Entity $site, array $contain = [])
+    {
+        if (empty($id)) {
+            throw new InvalidArgumentException('Category id or slug cannot be empty.');
+        }
+
+        $query = $this->find('all', [
+            'limit' => 1,
+            'conditions' => [
+                'OR' => [
+                    'Categories.id' => $id,
+                    'Categories.slug' => $id
+                ],
+                'Categories.site_id' => $site->id
+            ],
+            'contain' => $contain
+        ]);
+
+        $result = $query->first();
+
+        if (empty($result)) {
+            throw new RecordNotFoundException('Category not found.');
+        }
+
+        return $result;
+    }
 }

--- a/src/Model/Table/CategoriesTable.php
+++ b/src/Model/Table/CategoriesTable.php
@@ -39,6 +39,7 @@ class CategoriesTable extends Table
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('Tree');
+        $this->addBehavior('Muffin/Trash.Trash');
 
         $this->belongsTo('Cms.Sites');
         $this->belongsTo('ParentCategories', [

--- a/src/Model/Table/CategoriesTable.php
+++ b/src/Model/Table/CategoriesTable.php
@@ -90,7 +90,6 @@ class CategoriesTable extends Table
      */
     public function buildRules(RulesChecker $rules)
     {
-        $rules->add($rules->isUnique(['name', 'site_id']));
         $rules->add($rules->isUnique(['slug', 'site_id']));
         $rules->add($rules->existsIn(['parent_id'], 'ParentCategories'));
 

--- a/src/Model/Table/CategoriesTable.php
+++ b/src/Model/Table/CategoriesTable.php
@@ -1,12 +1,15 @@
 <?php
 namespace Cms\Model\Table;
 
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
 use Cms\Model\Entity\Category;
 use DateTime;
+use InvalidArgumentException;
 
 /**
  * Categories Model
@@ -92,5 +95,39 @@ class CategoriesTable extends Table
         $rules->add($rules->existsIn(['parent_id'], 'ParentCategories'));
 
         return $rules;
+    }
+
+    /**
+     * Fetch and return Site by id or slug.
+     *
+     * @param string $id Site id or slug.
+     * @return \Cake\ORM\Entity
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException
+     * @throws \InvalidArgumentException
+     */
+    public function getSite($id)
+    {
+        if (empty($id)) {
+            throw new InvalidArgumentException('Site id or slug cannot be empty.');
+        }
+
+        $query = $this->Sites->find('all', [
+            'limit' => 1,
+            'conditions' => [
+                'OR' => [
+                    'Sites.id' => $id,
+                    'Sites.slug' => $id
+                ],
+                'active' => true
+            ]
+        ]);
+
+        $result = $query->first();
+
+        if (empty($result)) {
+            throw new RecordNotFoundException('Site not found.');
+        }
+
+        return $result;
     }
 }

--- a/src/Model/Table/CategoriesTable.php
+++ b/src/Model/Table/CategoriesTable.php
@@ -68,8 +68,7 @@ class CategoriesTable extends Table
             ->allowEmpty('id', 'create');
 
         $validator
-            ->notEmpty('slug')
-            ->add('slug', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
+            ->notEmpty('slug');
 
         $validator
             ->requirePresence('name', 'create')
@@ -91,8 +90,8 @@ class CategoriesTable extends Table
      */
     public function buildRules(RulesChecker $rules)
     {
-        $rules->add($rules->isUnique(['slug']));
         $rules->add($rules->isUnique(['name', 'site_id']));
+        $rules->add($rules->isUnique(['slug', 'site_id']));
         $rules->add($rules->existsIn(['parent_id'], 'ParentCategories'));
 
         return $rules;

--- a/src/Template/Categories/add.ctp
+++ b/src/Template/Categories/add.ctp
@@ -17,6 +17,7 @@ echo $this->Html->scriptBlock(
         <div class="col-xs-12 col-md-6">
             <div class="box box-solid">
                 <?= $this->Form->create($category); ?>
+                <?= $this->Form->hidden('site_id', ['value' => $site->id]) ?>
                 <div class="box-body">
                     <div class="row">
                         <div class="col-md-6">
@@ -32,15 +33,10 @@ echo $this->Html->scriptBlock(
                     </div>
                     <div class="row">
                         <div class="col-md-6">
-                            <?= $this->Form->input('site_id') ?>
-                        </div>
-                        <div class="col-md-6">
                             <?= $this->Form->input('align_category_article_image', [
                                 'options' => $category->get('align_options')
                             ]) ?>
                         </div>
-                    </div>
-                    <div class="row">
                         <div class="col-md-6">
                         <?php
                             $label = $this->Form->label('hide_title');

--- a/src/Template/Categories/edit.ctp
+++ b/src/Template/Categories/edit.ctp
@@ -17,6 +17,7 @@ echo $this->Html->scriptBlock(
         <div class="col-xs-12 col-md-6">
             <div class="box box-solid">
                 <?= $this->Form->create($category); ?>
+                <?= $this->Form->hidden('site_id', ['value' => $site->id]) ?>
                 <div class="box-body">
                     <div class="row">
                         <div class="col-md-6">
@@ -32,15 +33,10 @@ echo $this->Html->scriptBlock(
                     </div>
                     <div class="row">
                         <div class="col-md-6">
-                            <?= $this->Form->input('site_id') ?>
-                        </div>
-                        <div class="col-md-6">
                             <?= $this->Form->input('align_category_article_image', [
                                 'options' => $category->get('align_options')
                             ]) ?>
                         </div>
-                    </div>
-                    <div class="row">
                         <div class="col-md-6">
                         <?php
                             $label = $this->Form->label('hide_title');

--- a/src/Template/Categories/index.ctp
+++ b/src/Template/Categories/index.ctp
@@ -18,11 +18,26 @@ echo $this->Html->scriptBlock(
     <h1>Categories
         <div class="pull-right">
             <div class="btn-group btn-group-sm" role="group">
-                <?= $this->Html->link(
+                <?= $this->Form->button(
                     '<i class="fa fa-plus"></i> ' . __('Add'),
-                    ['plugin' => $this->plugin, 'controller' => $this->name, 'action' => 'add'],
-                    ['escape' => false, 'title' => __('Add'), 'class' => 'btn btn-default']
+                    [
+                        'type' => 'button',
+                        'title' => __('Add'),
+                        'class' => 'btn btn-default dropdown-toggle',
+                        'data-toggle' => 'dropdown',
+                        'aria-haspopup' => 'true',
+                        'aria-expanded' => 'false'
+                    ]
                 ) ?>
+                <ul class="dropdown-menu dropdown-menu-right">
+                <?php foreach ($sites as $site) : ?>
+                    <li>
+                        <a href="<?= $this->Url->build(['action' => 'add', $site->slug]); ?>">
+                            <?= $site->name ?>
+                        </a>
+                    </li>
+                <?php endforeach; ?>
+                </ul>
             </div>
         </div>
     </h1>

--- a/src/Template/Categories/index.ctp
+++ b/src/Template/Categories/index.ctp
@@ -70,30 +70,30 @@ echo $this->Html->scriptBlock(
                                     <?php if ($category->parent_id) : ?>
                                         <?= $this->Form->postLink(
                                             '<i class="fa fa-arrow-up"></i>',
-                                            ['action' => 'move_node', $category->id, 'up'],
+                                            ['action' => 'moveNode', $category->site->slug, $category->slug, 'up'],
                                             ['title' => __('Move up'), 'class' => 'btn btn-default', 'escape' => false]
                                         ) ?>
                                         <?= $this->Form->postLink(
                                             '<i class="fa fa-arrow-down"></i>',
-                                            ['action' => 'move_node', $category->id, 'down'],
+                                            ['action' => 'moveNode', $category->site->slug, $category->slug, 'down'],
                                             ['title' => __('Move down'), 'class' => 'btn btn-default', 'escape' => false]
                                         ) ?>
                                     <?php endif; ?>
                                     <?= $this->Html->link(
                                         '<i class="fa fa-eye"></i>',
-                                        ['action' => 'view', $category->id],
+                                        ['action' => 'view', $category->site->slug, $category->slug],
                                         ['title' => __('View'), 'class' => 'btn btn-default', 'escape' => false]
                                     ) ?>
                                     <?= $this->Html->link(
                                         '<i class="fa fa-pencil"></i>',
-                                        ['action' => 'edit', $category->id],
+                                        ['action' => 'edit', $category->site->slug, $category->slug],
                                         ['title' => __('Edit'), 'class' => 'btn btn-default', 'escape' => false]
                                     ) ?>
                                     <?= $this->Form->postLink(
                                         '<i class="fa fa-trash"></i>',
-                                        ['action' => 'delete', $category->id],
+                                        ['action' => 'delete', $category->site->slug, $category->slug],
                                         [
-                                            'confirm' => __('Are you sure you want to delete # {0}?', $category->node),
+                                            'confirm' => __('Are you sure you want to delete # {0}?', $category->name),
                                             'title' => __('Delete'),
                                             'class' => 'btn btn-default',
                                             'escape' => false

--- a/src/Template/Sites/add.ctp
+++ b/src/Template/Sites/add.ctp
@@ -27,6 +27,7 @@ echo $this->Html->scriptBlock(
                             $label = $this->Form->label('active');
                             echo $this->Form->input('active', [
                                 'type' => 'checkbox',
+                                'checked' => true,
                                 'class' => 'square',
                                 'label' => false,
                                 'templates' => [

--- a/src/Template/Sites/index.ctp
+++ b/src/Template/Sites/index.ctp
@@ -49,6 +49,11 @@ echo $this->Html->scriptBlock(
                             <td class="actions">
                                 <div class="btn-group btn-group-xs" role="group">
                                     <?= $this->Html->link(
+                                        '<i class="fa fa-tag"></i>',
+                                        ['controller' => 'Categories', 'action' => 'add', $site->slug],
+                                        ['title' => __('Create Category'), 'class' => 'btn btn-default', 'escape' => false]
+                                    ) ?>
+                                    <?= $this->Html->link(
                                         '<i class="fa fa-eye"></i>',
                                         ['action' => 'view', $site->id],
                                         ['title' => __('View'), 'class' => 'btn btn-default', 'escape' => false]


### PR DESCRIPTION
Categories crud actions now require the `site_id` to be provided. Also `trashed` behavior was enabled for Categories table. Finally, `slug` behavior was slightly modified to include `site_id` in unique slug check conditions and the finder method was changed to `withTrashed`, to include soft-deleted records in the unique slug check.