### PR TITLE
File manager fixes (task #3982)

### DIFF
--- a/config/elfinder.php
+++ b/config/elfinder.php
@@ -5,6 +5,7 @@ return [
     'TinymceElfinder' => [
         'title' => 'File Manager',
         'client_options' => [
+            'requestType' => 'post',
             'width' => 900,
             'height' => 500,
             'resizable' => 'yes',

--- a/config/elfinder.php
+++ b/config/elfinder.php
@@ -38,6 +38,7 @@ return [
                     'tmbPath' => 'thumbnails',
                     'tmbSize' => 150,
                     'uploadOverwrite' => true,
+                    'uploadMaxSize' => (string)ini_get('upload_max_filesize'),
                     'checkSubfolders' => false,
                     'disabled' => []
                 ]

--- a/config/elfinder.php
+++ b/config/elfinder.php
@@ -37,7 +37,7 @@ return [
                     'tmbPathMode' => 0755,
                     'tmbPath' => 'thumbnails',
                     'tmbSize' => 150,
-                    'uploadOverwrite' => false,
+                    'uploadOverwrite' => true,
                     'checkSubfolders' => false,
                     'disabled' => []
                 ]


### PR DESCRIPTION
- Allow overwriting files with the same name.
- Limit upload file size to PHP's upload max filesize.
- Switched request method to POST to fix failures with multiple file uploads.