### PR TITLE
Display search title (task #3912)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -34,10 +34,16 @@ class AppController extends BaseController
             return;
         }
 
-        // pass article types to all views
+        // pass article types to all Views
         $this->set('types', $table->getTypes());
 
+        $searchQuery = $this->request->query('q') ?: '';
+
+        $searchTitle = $searchQuery ? __('Search Results for') . ' \'' . $searchQuery . '\'' : '';
+        // pass search title to all Views
+        $this->set('searchTitle', $searchTitle);
+
         // set search query on Articles table
-        $table->setSearchQuery($this->request->query('q') ?: '');
+        $table->setSearchQuery($searchQuery);
     }
 }

--- a/src/Template/Articles/type.ctp
+++ b/src/Template/Articles/type.ctp
@@ -12,7 +12,7 @@ $this->Breadcrumbs->add($site->name, [
 $this->Breadcrumbs->add($types[$type]['label'], null, ['class' => 'active']);
 ?>
 <section class="content-header">
-    <h1><?= h($types[$type]['label']) ?></h1>
+    <h1><?= h($types[$type]['label']) ?> <small><?= $searchTitle ?></small></h1>
     <?= $this->Breadcrumbs->render(
         ['class' => 'breadcrumb'],
         ['separator' => false]

--- a/src/Template/Categories/view.ctp
+++ b/src/Template/Categories/view.ctp
@@ -12,7 +12,7 @@ $this->Breadcrumbs->add($site->name, [
 $this->Breadcrumbs->add($category->name, null, ['class' => 'active']);
 ?>
 <section class="content-header">
-    <h1><?= h($category->name) ?></h1>
+    <h1><?= h($category->name) ?> <small><?= $searchTitle ?></small></h1>
     <?= $this->Breadcrumbs->render(
         ['class' => 'breadcrumb'],
         ['separator' => false]

--- a/src/Template/Sites/view.ctp
+++ b/src/Template/Sites/view.ctp
@@ -1,6 +1,6 @@
 <?php use Cake\Event\Event; ?>
 <section class="content-header">
-    <h1><?= h($site->name) ?></h1>
+    <h1><?= h($site->name) ?> <small><?= $searchTitle ?></small></h1>
     <div class="btn-group btn-group-sm toolbox pull-right" role="group">
         <?= $this->element('Sites/toolbar', ['site' => $site, 'user' => $user]) ?>
     </div>


### PR DESCRIPTION
Display search title, for example `Search Results for 'foo'`.