### PR TITLE
Event names enumeration (task #4352)

### DIFF
--- a/src/Event/EventName.php
+++ b/src/Event/EventName.php
@@ -1,0 +1,12 @@
+<?php
+namespace Cms\Event;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Event Name enum
+ */
+class EventName extends Enum
+{
+    const VIEW_MANAGE_BEFORE_RENDER = 'Cms.View.element.beforeRender';
+}

--- a/src/Event/View/SitesManageListener.php
+++ b/src/Event/View/SitesManageListener.php
@@ -3,6 +3,7 @@ namespace Cms\Event\View;
 
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
+use Cms\Event\EventName;
 
 class SitesManageListener implements EventListenerInterface
 {
@@ -14,7 +15,7 @@ class SitesManageListener implements EventListenerInterface
     public function implementedEvents()
     {
         return [
-            'Cms.View.element.beforeRender' => 'sitesManageElement',
+            (string)EventName::VIEW_MANAGE_BEFORE_RENDER() => 'sitesManageElement',
         ];
     }
 


### PR DESCRIPTION
Use [php-enum](https://github.com/myclabs/php-enum) library to define event names enum. Modified all events to use `EventName` enumeration class.