### PR TITLE
Fixed weird problem with buttons set to float:right. (task #5501)

### DIFF
--- a/src/Template/Sites/view.ctp
+++ b/src/Template/Sites/view.ctp
@@ -11,10 +11,10 @@
  */
 ?>
 <section class="content-header">
+	<div class="btn-group btn-group-sm toolbox pull-right" role="group">
+		<?= $this->element('Cms.Sites/toolbar', ['site' => $site, 'user' => $user]) ?>
+	</div>
     <h1><?= h($site->name) ?> <small><?= $searchTitle ?></small></h1>
-    <div class="btn-group btn-group-sm toolbox pull-right" role="group">
-        <?= $this->element('Cms.Sites/toolbar', ['site' => $site, 'user' => $user]) ?>
-    </div>
 </section>
 <section class="content">
     <?= $this->element('Cms.Sites/manage', [


### PR DESCRIPTION
The problem was solved by reordering the html elements. It is likely due to poor implementation of the standards by certain browsers.

( See 9.4.1 -- Block formatting contexts https://www.w3.org/TR/CSS21/visuren.html#block-formatting )