### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,10 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
-        }
-    ],
     "require": {
-        "burzum/cakephp-file-storage": "dev-branch-2.0",
-        "burzum/cakephp-imagine-plugin": "dev-master#d21baf7378271d536982c8c0867fab3dcfa24cc8",
-        "cakephp/cakephp": "^3.5 <3.7",
+        "burzum/cakephp-file-storage": "^2.0",
+        "burzum/cakephp-imagine-plugin": "^2.0",
+        "cakephp/cakephp": "^3.8",
         "hashmode/cakephp-tinymce-elfinder": "^1.0",
         "muffin/slug": "^1.0",
         "muffin/trash": "^2.1"

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/config/Seeds/ArticlesSeed.php
+++ b/config/Seeds/ArticlesSeed.php
@@ -1,5 +1,6 @@
 <?php
-use Cake\Utility\Inflector;
+
+use Cake\Utility\Text;
 use Faker\Factory;
 use Phinx\Seed\AbstractSeed;
 
@@ -24,7 +25,7 @@ class ArticlesSeed extends AbstractSeed
         for ($i = 0; $i < 50; $i++) {
             $uuid = Faker\Provider\Uuid::uuid();
             $title = Faker\Provider\Lorem::sentence(rand(3, 5), true);
-            $slug = Inflector::slug(strtolower($title));
+            $slug = Text::slug(strtolower($title));
             $excerpt = Faker\Provider\Lorem::text(150);
             $content = Faker\Provider\Lorem::paragraphs(rand(3, 5), true);
             $data[] = [

--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -12,8 +12,6 @@
 namespace Cms\Controller;
 
 use Cake\Http\Exception\NotFoundException;
-use Cms\Controller\AppController;
-use Cms\Controller\UploadTrait;
 
 /**
  * Articles Controller

--- a/src/Controller/CategoriesController.php
+++ b/src/Controller/CategoriesController.php
@@ -11,7 +11,6 @@
  */
 namespace Cms\Controller;
 
-use Cms\Controller\AppController;
 
 /**
  * Categories Controller

--- a/src/Controller/CategoriesController.php
+++ b/src/Controller/CategoriesController.php
@@ -11,7 +11,6 @@
  */
 namespace Cms\Controller;
 
-
 /**
  * Categories Controller
  *

--- a/src/Controller/SitesController.php
+++ b/src/Controller/SitesController.php
@@ -11,7 +11,6 @@
  */
 namespace Cms\Controller;
 
-
 /**
  * Sites Controller
  *

--- a/src/Controller/SitesController.php
+++ b/src/Controller/SitesController.php
@@ -11,7 +11,6 @@
  */
 namespace Cms\Controller;
 
-use Cms\Controller\AppController;
 
 /**
  * Sites Controller

--- a/src/Model/Table/ArticlesTable.php
+++ b/src/Model/Table/ArticlesTable.php
@@ -20,7 +20,6 @@ use Cake\Event\Event;
 use Cake\I18n\Time;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
-use Cake\ORM\ResultSet;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;

--- a/src/Model/Table/ArticlesTable.php
+++ b/src/Model/Table/ArticlesTable.php
@@ -124,36 +124,36 @@ class ArticlesTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->requirePresence('title', 'create')
-            ->notEmpty('title');
+            ->notEmptyString('title');
 
         $validator
-            ->notEmpty('slug')
+            ->notEmptyString('slug')
             ->add('slug', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
         $validator
             ->requirePresence('content', 'create')
-            ->allowEmpty('content');
+            ->allowEmptyString('content');
 
         $validator
             ->requirePresence('category_id', 'create')
-            ->notEmpty('category_id');
+            ->notEmptyString('category_id');
 
         $validator
             ->dateTime('publish_date')
             ->requirePresence('publish_date', 'create')
-            ->notEmpty('publish_date');
+            ->notEmptyDateTime('publish_date');
 
         $validator
             ->requirePresence('site_id', 'create')
-            ->notEmpty('site_id');
+            ->notEmptyString('site_id');
 
         $validator
             ->requirePresence('type', 'create')
-            ->notEmpty('type');
+            ->notEmptyString('type');
 
         return $validator;
     }

--- a/src/Model/Table/ArticlesTable.php
+++ b/src/Model/Table/ArticlesTable.php
@@ -18,7 +18,6 @@ use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetInterface;
 use Cake\Event\Event;
 use Cake\I18n\Time;
-use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;

--- a/src/Model/Table/CategoriesTable.php
+++ b/src/Model/Table/CategoriesTable.php
@@ -86,18 +86,18 @@ class CategoriesTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
-            ->notEmpty('slug');
+            ->notEmptyString('slug');
 
         $validator
             ->requirePresence('name', 'create')
-            ->notEmpty('name');
+            ->notEmptyString('name');
 
         $validator
             ->requirePresence('site_id', 'create')
-            ->notEmpty('site_id');
+            ->notEmptyString('site_id');
 
         return $validator;
     }

--- a/src/Model/Table/SitesTable.php
+++ b/src/Model/Table/SitesTable.php
@@ -12,7 +12,6 @@
 namespace Cms\Model\Table;
 
 use Cake\Datasource\EntityInterface;
-use Cake\ORM\Entity;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;

--- a/src/Model/Table/SitesTable.php
+++ b/src/Model/Table/SitesTable.php
@@ -64,21 +64,20 @@ class SitesTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->requirePresence('name', 'create')
-            ->notEmpty('name')
+            ->notEmptyString('name')
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
         $validator
-            ->notEmpty('slug')
+            ->notEmptyString('slug')
             ->add('slug', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
         $validator
             ->boolean('active')
-            ->requirePresence('active', 'create')
-            ->notEmpty('active');
+            ->requirePresence('active', 'create');
 
         return $validator;
     }

--- a/tests/App/Application.php
+++ b/tests/App/Application.php
@@ -14,7 +14,6 @@
  */
 namespace Cms\Test\App;
 
-use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\BaseApplication;
 use Cake\Routing\Middleware\AssetMiddleware;

--- a/tests/TestCase/Controller/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/ArticlesControllerTest.php
@@ -3,7 +3,8 @@ namespace Cms\Test\TestCase\Controller;
 
 use Cake\ORM\ResultSet;
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\IntegrationTestCase;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Cms\Model\Entity\Article;
 use Cms\Model\Entity\Site;
 
@@ -11,8 +12,10 @@ use Cms\Model\Entity\Site;
  * @property \Cms\Model\Table\ArticlesTable $Articles
  * @property \Cms\Model\Table\ArticleFeaturedImagesTable $ArticleFeaturedImages
  */
-class ArticlesControllerTest extends IntegrationTestCase
+class ArticlesControllerTest extends TestCase
 {
+    use IntegrationTestTrait;
+
     public $fixtures = [
         'plugin.Cms.Articles',
         'plugin.Cms.Categories',
@@ -37,7 +40,7 @@ class ArticlesControllerTest extends IntegrationTestCase
         /**
          * @var \Cms\Model\Table\ArticlesTable $table
          */
-        $table = TableRegistry::get('Cms.Articles');
+        $table = TableRegistry::getTableLocator()->get('Cms.Articles');
         $this->Articles = $table;
 
         // Save featured image

--- a/tests/TestCase/Controller/CategoriesControllerTest.php
+++ b/tests/TestCase/Controller/CategoriesControllerTest.php
@@ -2,7 +2,8 @@
 namespace Cms\Test\TestCase\Controller;
 
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\IntegrationTestCase;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Cms\Model\Entity\Category;
 use Cms\Model\Entity\Site;
 
@@ -10,8 +11,10 @@ use Cms\Model\Entity\Site;
  * @property \Cms\Model\Table\CategoriesTable $Categories
  * @property \Cms\Model\Table\ArticleFeaturedImagesTable $ArticleFeaturedImages
  */
-class CategoriesControllerTest extends IntegrationTestCase
+class CategoriesControllerTest extends TestCase
 {
+    use IntegrationTestTrait;
+
     /**
      * Category table
      *
@@ -43,7 +46,7 @@ class CategoriesControllerTest extends IntegrationTestCase
         /**
          * @var \Cms\Model\Table\CategoriesTable $table
          */
-        $table = TableRegistry::get('Cms.Categories');
+        $table = TableRegistry::getTableLocator()->get('Cms.Categories');
         $this->Categories = $table;
 
         // Save featured image

--- a/tests/TestCase/Controller/SitesControllerTest.php
+++ b/tests/TestCase/Controller/SitesControllerTest.php
@@ -3,14 +3,17 @@ namespace Cms\Test\TestCase\Controller;
 
 use Cake\ORM\ResultSet;
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\IntegrationTestCase;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Cms\Model\Entity\Site;
 
 /**
  * @property \Cms\Model\Table\SitesTable $Sites
  */
-class SitesControllerTest extends IntegrationTestCase
+class SitesControllerTest extends TestCase
 {
+    use IntegrationTestTrait;
+
     public $fixtures = [
         'plugin.Cms.Sites',
         'plugin.Cms.Articles',
@@ -35,7 +38,7 @@ class SitesControllerTest extends IntegrationTestCase
         /**
          * @var \Cms\Model\Table\SitesTable $table
          */
-        $table = TableRegistry::get('Cms.Sites');
+        $table = TableRegistry::getTableLocator()->get('Cms.Sites');
         $this->Sites = $table;
 
         // Save featured image

--- a/tests/TestCase/Model/Table/ArticlesTableTest.php
+++ b/tests/TestCase/Model/Table/ArticlesTableTest.php
@@ -46,11 +46,11 @@ class ArticlesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Articles') ? [] : ['className' => 'Cms\Model\Table\ArticlesTable'];
+        $config = TableRegistry::getTableLocator()->exists('Articles') ? [] : ['className' => 'Cms\Model\Table\ArticlesTable'];
         /**
          * @var \Cms\Model\Table\ArticlesTable $table
          */
-        $table = TableRegistry::get('Articles', $config);
+        $table = TableRegistry::getTableLocator()->get('Articles', $config);
         $this->Articles = $table;
 
         // load default plugin config

--- a/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -49,18 +49,18 @@ class CategoriesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Categories') ? [] : ['className' => 'Cms\Model\Table\CategoriesTable'];
+        $config = TableRegistry::getTableLocator()->exists('Categories') ? [] : ['className' => 'Cms\Model\Table\CategoriesTable'];
         /**
          * @var \Cms\Model\Table\CategoriesTable $table
          */
-        $table = TableRegistry::get('Categories', $config);
+        $table = TableRegistry::getTableLocator()->get('Categories', $config);
         $this->CategoriesTable = $table;
 
-        $config = TableRegistry::exists('Sites') ? [] : ['className' => 'Cms\Model\Table\SitesTable'];
+        $config = TableRegistry::getTableLocator()->exists('Sites') ? [] : ['className' => 'Cms\Model\Table\SitesTable'];
         /**
          * @var \Cms\Model\Table\SitesTable $table
          */
-        $table = TableRegistry::get('Sites', $config);
+        $table = TableRegistry::getTableLocator()->get('Sites', $config);
         $this->Sites = $table;
     }
 

--- a/tests/TestCase/Model/Table/SitesTableTest.php
+++ b/tests/TestCase/Model/Table/SitesTableTest.php
@@ -42,11 +42,11 @@ class SitesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Sites') ? [] : ['className' => 'Cms\Model\Table\SitesTable'];
+        $config = TableRegistry::getTableLocator()->exists('Sites') ? [] : ['className' => 'Cms\Model\Table\SitesTable'];
         /**
          * @var \Cms\Model\Table\SitesTable $table
          */
-        $table = TableRegistry::get('Sites', $config);
+        $table = TableRegistry::getTableLocator()->get('Sites', $config);
         $this->Sites = $table;
     }
 

--- a/tests/TestCase/View/ShortcodeTest.php
+++ b/tests/TestCase/View/ShortcodeTest.php
@@ -3,7 +3,6 @@ namespace Cms\Test\TestCase\View;
 
 use Cms\View\Shortcode;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 /**
  * Cms\Model\Table\ArticlesTable Test Case

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -1,8 +1,6 @@
 <?php
 namespace Cms\Test\App\Config;
 
-use Cake\Core\Configure;
-use Cake\Core\Plugin;
 use Cake\Routing\Router;
 
 Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.

